### PR TITLE
Metadata config and pipeline options (#2081)

### DIFF
--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/constants/Constants.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/constants/Constants.java
@@ -21,6 +21,9 @@ public class Constants {
   /* The source type value for MySql databases */
   public static final String MYSQL_SOURCE_TYPE = "mysql";
 
+  /* The source type value for CASSANDRA databases */
+  public static final String CASSANDRA_SOURCE_TYPE = "cassandra";
+
   /* The value for Oracle databases in the source type key */
   public static final String ORACLE_SOURCE_TYPE = "oracle";
 

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/metadata/CassandraSourceMetadata.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/metadata/CassandraSourceMetadata.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.metadata;
+
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.ColumnPK;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.NameAndCols;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.Schema;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnDefinition;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceTable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The {@code CassandraSourceMetadata} class is responsible for generating metadata from a Cassandra
+ * schema using a {@link ResultSet}, converting it into a Spanner-compatible format, and managing
+ * this metadata to facilitate schema migration operations.
+ *
+ * <p>This class supports the following functionalities:
+ *
+ * <ul>
+ *   <li>Extracting table, column, and primary key information from Cassandra's schema.
+ *   <li>Converting Cassandra schema details into Spanner-compatible objects like {@link
+ *       SourceTable}.
+ *   <li>Updating a provided {@link Schema} instance with the extracted metadata.
+ * </ul>
+ *
+ * <p>The metadata extraction process uses the {@link ResultSet} containing the schema details from
+ * Cassandra, such as table names, column definitions, data types, and primary key details.
+ *
+ * <p><strong>Note:</strong> This class does not perform direct database interactions; it relies on
+ * a pre-populated {@link ResultSet}.
+ */
+public class CassandraSourceMetadata {
+
+  private Map<String, SourceTable> sourceTableMap;
+  private Map<String, NameAndCols> nameAndColsMap;
+
+  private final ResultSet resultSet;
+
+  /**
+   * Retrieves the map of source tables.
+   *
+   * @return A {@link Map} where the key is a {@link String} representing the table name, and the
+   *     value is a {@link SourceTable} containing the source table details.
+   */
+  public Map<String, SourceTable> getSourceTableMap() {
+    return sourceTableMap;
+  }
+
+  /**
+   * Sets the map of source tables.
+   *
+   * @param sourceTableMap A {@link Map} where the key is a {@link String} representing the table
+   *     name, and the value is a {@link SourceTable} containing the source table details.
+   */
+  public void setSourceTableMap(Map<String, SourceTable> sourceTableMap) {
+    this.sourceTableMap = sourceTableMap;
+  }
+
+  /**
+   * Retrieves the map of names and columns.
+   *
+   * @return A {@link Map} where the key is a {@link String} representing the table name, and the
+   *     value is a {@link NameAndCols} containing the name and columns metadata.
+   */
+  public Map<String, NameAndCols> getNameAndColsMap() {
+    return nameAndColsMap;
+  }
+
+  /**
+   * Sets the map of names and columns.
+   *
+   * @param nameAndColsMap A {@link Map} where the key is a {@link String} representing the table
+   *     name, and the value is a {@link NameAndCols} containing the name and columns metadata.
+   */
+  public void setNameAndColsMap(Map<String, NameAndCols> nameAndColsMap) {
+    this.nameAndColsMap = nameAndColsMap;
+  }
+
+  /**
+   * Private constructor to initialize {@link CassandraSourceMetadata}.
+   *
+   * @param resultSet The {@link ResultSet} containing Cassandra schema metadata. Cannot be null.
+   */
+  private CassandraSourceMetadata(ResultSet resultSet) {
+    this.resultSet = Objects.requireNonNull(resultSet, "ResultSet cannot be null");
+  }
+
+  /**
+   * Generates a map of table names to {@link SourceTable} objects, representing the schema of the
+   * Cassandra source in a Spanner-compatible format.
+   *
+   * @return A map where keys are table names and values are {@link SourceTable} objects containing
+   *     schema details.
+   */
+  private Map<String, SourceTable> generateSourceSchema() {
+    Map<String, Map<String, SourceColumnDefinition>> colDefinitions = new HashMap<>();
+    Map<String, List<ColumnPK>> columnPKs = new HashMap<>();
+    Map<String, List<String>> columnIds = new HashMap<>();
+    Set<String> tableNames = new HashSet<>();
+
+    resultSet.forEach(
+        row -> {
+          String tableName = row.getString("table_name");
+          String columnName = row.getString("column_name");
+          String dataType = row.getString("type");
+          String kind = row.getString("kind");
+
+          tableNames.add(tableName);
+
+          colDefinitions
+              .computeIfAbsent(tableName, k -> new HashMap<>())
+              .put(
+                  columnName,
+                  new SourceColumnDefinition(
+                      columnName, new SourceColumnType(dataType, null, null)));
+
+          if (isPrimaryKey(kind)) {
+            columnPKs
+                .computeIfAbsent(tableName, k -> new ArrayList<>())
+                .add(new ColumnPK(columnName, 1));
+          }
+
+          columnIds.computeIfAbsent(tableName, k -> new ArrayList<>()).add(columnName);
+        });
+
+    return tableNames.stream()
+        .collect(
+            Collectors.toMap(
+                tableName -> tableName,
+                tableName ->
+                    new SourceTable(
+                        tableName,
+                        null,
+                        columnIds.getOrDefault(tableName, List.of()).toArray(new String[0]),
+                        colDefinitions.getOrDefault(tableName, Map.of()),
+                        columnPKs.getOrDefault(tableName, List.of()).toArray(new ColumnPK[0]))));
+  }
+
+  /**
+   * Updates the provided {@link Schema} with metadata generated from the Cassandra {@link
+   * ResultSet}.
+   *
+   * <p>This method extracts schema details, transforms them into Spanner-compatible objects, and
+   * sets the corresponding properties in the provided {@link Schema}.
+   */
+  public void generateSourceSchemaMap() {
+    Map<String, SourceTable> sourceTableMap = generateSourceSchema();
+    this.setSourceTableMap(sourceTableMap);
+    this.setNameAndColsMap(convertSourceToNameAndColsTable(sourceTableMap.values()));
+  }
+
+  /**
+   * Determines whether a column is part of the primary key based on its kind.
+   *
+   * @param kind The column kind, such as "partition_key" or "clustering".
+   * @return {@code true} if the column is a primary key; {@code false} otherwise.
+   */
+  private boolean isPrimaryKey(String kind) {
+    return "partition_key".equals(kind) || "clustering".equals(kind);
+  }
+
+  /**
+   * Converts a collection of {@link SourceTable} objects into a map of table names to {@link
+   * NameAndCols}.
+   *
+   * @param tables A collection of {@link SourceTable} objects representing the Cassandra schema.
+   * @return A map where keys are table names and values are {@link NameAndCols}.
+   */
+  private Map<String, NameAndCols> convertSourceToNameAndColsTable(Collection<SourceTable> tables) {
+    return tables.stream()
+        .collect(Collectors.toMap(SourceTable::getName, this::convertSourceTableToNameAndCols));
+  }
+
+  /**
+   * Converts a single {@link SourceTable} into a {@link NameAndCols} instance.
+   *
+   * @param sourceTable The {@link SourceTable} to convert.
+   * @return A {@link NameAndCols} object containing the table name and column names.
+   */
+  private NameAndCols convertSourceTableToNameAndCols(SourceTable sourceTable) {
+    Map<String, String> columnNames =
+        sourceTable.getColDefs().values().stream()
+            .collect(
+                Collectors.toMap(SourceColumnDefinition::getName, SourceColumnDefinition::getName));
+
+    return new NameAndCols(sourceTable.getName(), columnNames);
+  }
+
+  /**
+   * Builder class for creating instances of {@link CassandraSourceMetadata}.
+   *
+   * <p>The builder allows for incremental configuration of the {@link ResultSet} and {@link Schema}
+   * before constructing the final {@link CassandraSourceMetadata} instance.
+   */
+  public static class Builder {
+    private ResultSet resultSet;
+
+    /**
+     * Sets the {@link ResultSet} for the builder.
+     *
+     * @param resultSet The {@link ResultSet} containing Cassandra schema information.
+     * @return The current {@link Builder} instance.
+     */
+    public Builder setResultSet(ResultSet resultSet) {
+      this.resultSet = resultSet;
+      return this;
+    }
+
+    /**
+     * Builds an instance of {@link CassandraSourceMetadata}, generating and setting the schema
+     * metadata.
+     *
+     * @return A fully constructed {@link CassandraSourceMetadata} instance.
+     */
+    public CassandraSourceMetadata build() {
+      CassandraSourceMetadata cassandraSourceMetadata = new CassandraSourceMetadata(resultSet);
+      cassandraSourceMetadata.generateSourceSchemaMap();
+      return cassandraSourceMetadata;
+    }
+  }
+}

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/Schema.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/Schema.java
@@ -69,6 +69,20 @@ public class Schema implements Serializable {
   public Schema(
       Map<String, SpannerTable> spSchema,
       Map<String, SyntheticPKey> syntheticPKeys,
+      Map<String, SourceTable> srcSchema,
+      Map<String, NameAndCols> toSpanner,
+      Map<String, NameAndCols> toSource) {
+    this.spSchema = spSchema;
+    this.syntheticPKeys = syntheticPKeys;
+    this.srcSchema = srcSchema;
+    this.toSpanner = toSpanner;
+    this.toSource = toSource;
+    this.empty = (spSchema == null || srcSchema == null);
+  }
+
+  public Schema(
+      Map<String, SpannerTable> spSchema,
+      Map<String, SyntheticPKey> syntheticPKeys,
       Map<String, SourceTable> srcSchema) {
     this.spSchema = spSchema;
     this.syntheticPKeys = syntheticPKeys;

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/shard/CassandraShard.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/shard/CassandraShard.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.shard;
+
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.datastax.oss.driver.api.core.config.TypedDriverOption;
+import java.util.List;
+import java.util.Objects;
+
+public class CassandraShard extends Shard {
+  private final OptionsMap optionsMap;
+
+  public CassandraShard(OptionsMap optionsMap) {
+    super();
+    this.optionsMap = optionsMap;
+    validateFields();
+    extractAndSetHostAndPort();
+  }
+
+  private void validateFields() {
+    if (getContactPoints() == null || getContactPoints().isEmpty()) {
+      throw new IllegalArgumentException("CONTACT_POINTS cannot be null or empty.");
+    }
+    if (getKeySpaceName() == null || getKeySpaceName().isEmpty()) {
+      throw new IllegalArgumentException("SESSION_KEYSPACE cannot be null or empty.");
+    }
+  }
+
+  private void extractAndSetHostAndPort() {
+    String firstContactPoint = getContactPoints().get(0);
+    String[] parts = firstContactPoint.split(":");
+
+    if (parts.length < 2) {
+      throw new IllegalArgumentException("Invalid contact point format: " + firstContactPoint);
+    }
+
+    String host = parts[0];
+    String port = parts[1];
+
+    setHost(host);
+    setPort(port);
+  }
+
+  private String getOptionValue(TypedDriverOption<String> key) {
+    return optionsMap.get(key);
+  }
+
+  private List<String> getOptionValueList(TypedDriverOption<List<String>> key) {
+    return optionsMap.get(key);
+  }
+
+  // Getters that fetch data from OptionsMap
+  public List<String> getContactPoints() {
+    return getOptionValueList(TypedDriverOption.CONTACT_POINTS);
+  }
+
+  public String getKeySpaceName() {
+    return getOptionValue(TypedDriverOption.SESSION_KEYSPACE);
+  }
+
+  public String getUsername() {
+    return getOptionValue(TypedDriverOption.AUTH_PROVIDER_USER_NAME);
+  }
+
+  public OptionsMap getOptionsMap() {
+    return this.optionsMap;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "CassandraShard{logicalShardId='%s', contactPoints=%s, keyspace='%s', host='%s', port='%s'}",
+        getLogicalShardId(), getContactPoints(), getKeySpaceName(), getHost(), getPort());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CassandraShard)) {
+      return false;
+    }
+    CassandraShard that = (CassandraShard) o;
+    return Objects.equals(getContactPoints(), that.getContactPoints())
+        && Objects.equals(getKeySpaceName(), that.getKeySpaceName());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getContactPoints(), getKeySpaceName());
+  }
+}

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/utils/CassandraConfigFileReader.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/utils/CassandraConfigFileReader.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.utils;
+
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.CassandraShard;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import java.io.FileNotFoundException;
+import java.util.Collections;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for reading and parsing a Cassandra configuration file from GCS into a
+ * CassandraShard object.
+ */
+public class CassandraConfigFileReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CassandraConfigFileReader.class);
+
+  /**
+   * Reads the Cassandra configuration file from the specified GCS path and converts it into a list
+   * of CassandraShard objects.
+   *
+   * @param cassandraConfigFilePath the GCS path of the Cassandra configuration file.
+   * @return a list containing the parsed CassandraShard.
+   */
+  public List<Shard> getCassandraShard(String cassandraConfigFilePath) {
+    try {
+      LOG.info("Reading Cassandra configuration from: {}", cassandraConfigFilePath);
+      OptionsMap optionsMap =
+          CassandraDriverConfigLoader.getOptionsMapFromFile(cassandraConfigFilePath);
+      CassandraShard shard = new CassandraShard(optionsMap);
+      LOG.info("Successfully created CassandraShard: {}", shard);
+      return Collections.singletonList(shard);
+    } catch (FileNotFoundException e) {
+      throw new IllegalArgumentException(
+          "Configuration file not found: " + cassandraConfigFilePath, e);
+    }
+  }
+}

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/metadata/CassandraSourceMetadataTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/metadata/CassandraSourceMetadataTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.metadata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.NameAndCols;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.Schema;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceTable;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CassandraSourceMetadataTest {
+
+  @Mock private ResultSet mockResultSet;
+  @Mock private Row mockRow1;
+  @Mock private Row mockRow2;
+  @Mock private Schema mockSchema;
+
+  private CassandraSourceMetadata.Builder builder;
+
+  @Before
+  public void setUp() {
+    builder = new CassandraSourceMetadata.Builder();
+  }
+
+  @Test
+  public void testGenerateSourceSchema() {
+    doAnswer(
+            invocation -> {
+              Iterable<Row> iterable = Arrays.asList(mockRow1, mockRow2);
+              iterable.forEach(invocation.getArgument(0));
+              return null;
+            })
+        .when(mockResultSet)
+        .forEach(any());
+
+    when(mockRow1.getString("table_name")).thenReturn("table1");
+    when(mockRow1.getString("column_name")).thenReturn("column1");
+    when(mockRow1.getString("type")).thenReturn("text");
+    when(mockRow1.getString("kind")).thenReturn("partition_key");
+
+    when(mockRow2.getString("table_name")).thenReturn("table1");
+    when(mockRow2.getString("column_name")).thenReturn("column2");
+    when(mockRow2.getString("type")).thenReturn("int");
+    when(mockRow2.getString("kind")).thenReturn("clustering");
+
+    CassandraSourceMetadata metadata = builder.setResultSet(mockResultSet).build();
+
+    assertNotNull("Metadata should be generated successfully", metadata);
+  }
+
+  @Test
+  public void testGenerateNamesColsMap() {
+    doAnswer(
+            invocation -> {
+              Iterable<Row> iterable = Arrays.asList(mockRow1, mockRow2);
+              iterable.forEach(invocation.getArgument(0));
+              return null;
+            })
+        .when(mockResultSet)
+        .forEach(any());
+
+    when(mockRow1.getString("table_name")).thenReturn("table1");
+    when(mockRow1.getString("column_name")).thenReturn("column1");
+    when(mockRow1.getString("type")).thenReturn("text");
+    when(mockRow1.getString("kind")).thenReturn("partition_key");
+
+    when(mockRow2.getString("table_name")).thenReturn("table1");
+    when(mockRow2.getString("column_name")).thenReturn("column2");
+    when(mockRow2.getString("type")).thenReturn("int");
+    when(mockRow2.getString("kind")).thenReturn("clustering");
+
+    CassandraSourceMetadata metadata = builder.setResultSet(mockResultSet).build();
+
+    assertNotNull("Metadata should be generated successfully", metadata);
+
+    Map<String, NameAndCols> nameAndColsMap = metadata.getNameAndColsMap();
+    assertEquals(1, nameAndColsMap.size());
+    NameAndCols nameAndCols = nameAndColsMap.get("table1");
+    assertNotNull("NameAndCols should be generated successfully", nameAndCols);
+    assertEquals(2, nameAndCols.getCols().size());
+  }
+
+  @Test
+  public void testGenerateSourceTablesMap() {
+    doAnswer(
+            invocation -> {
+              Iterable<Row> iterable = Arrays.asList(mockRow1, mockRow2);
+              iterable.forEach(invocation.getArgument(0));
+              return null;
+            })
+        .when(mockResultSet)
+        .forEach(any());
+
+    when(mockRow1.getString("table_name")).thenReturn("table1");
+    when(mockRow1.getString("column_name")).thenReturn("column1");
+    when(mockRow1.getString("type")).thenReturn("text");
+    when(mockRow1.getString("kind")).thenReturn("partition_key");
+
+    when(mockRow2.getString("table_name")).thenReturn("table1");
+    when(mockRow2.getString("column_name")).thenReturn("column2");
+    when(mockRow2.getString("type")).thenReturn("int");
+    when(mockRow2.getString("kind")).thenReturn("clustering");
+
+    CassandraSourceMetadata metadata = builder.setResultSet(mockResultSet).build();
+
+    assertNotNull("Metadata should be generated successfully", metadata);
+
+    Map<String, SourceTable> sourceTableMap = metadata.getSourceTableMap();
+    assertEquals(1, sourceTableMap.size());
+    SourceTable sourceTable = sourceTableMap.get("table1");
+    assertNotNull("SourceTable should be generated successfully", sourceTable);
+    assertEquals(2, sourceTable.getColDefs().size());
+  }
+}

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaTest.java
@@ -26,12 +26,26 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class SchemaTest {
 
   @Test
   public void verifyTableInSessionTestCorrect() {
     Schema schema = getSchemaObject();
+    schema.generateMappings();
+    try {
+      schema.verifyTableInSession("cart");
+    } catch (Exception e) {
+      fail("No exception should have been thrown for this case");
+    }
+  }
+
+  @Test
+  public void verifyTableInSessionTestAndPopulationCorrect() {
+    Schema schema = getAllSchemaObject();
     schema.generateMappings();
     try {
       schema.verifyTableInSession("cart");
@@ -88,6 +102,19 @@ public class SchemaTest {
     // Add SpSchema.
     Map<String, SpannerTable> spSchema = getSampleSpSchema();
     Schema expectedSchema = new Schema(spSchema, syntheticPKeys, srcSchema);
+    expectedSchema.setToSpanner(new HashMap<String, NameAndCols>());
+    expectedSchema.setToSource(new HashMap<String, NameAndCols>());
+    expectedSchema.setSrcToID(new HashMap<String, NameAndCols>());
+    expectedSchema.setSpannerToID(new HashMap<String, NameAndCols>());
+    return expectedSchema;
+  }
+
+  private static Schema getAllSchemaObject() {
+    // Add SrcSchema.
+    Map<String, SourceTable> srcSchema = getSampleSrcSchema();
+    // Add SpSchema.
+    Map<String, SpannerTable> spSchema = getSampleSpSchema();
+    Schema expectedSchema = new Schema(spSchema, null, srcSchema, null, null);
     expectedSchema.setToSpanner(new HashMap<String, NameAndCols>());
     expectedSchema.setToSource(new HashMap<String, NameAndCols>());
     expectedSchema.setSrcToID(new HashMap<String, NameAndCols>());

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/shard/CassandraShardTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/shard/CassandraShardTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.shard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.datastax.oss.driver.api.core.config.TypedDriverOption;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CassandraShardTest {
+
+  private OptionsMap optionsMap;
+  private List<String> contactPoints;
+
+  @Before
+  public void setUp() {
+    optionsMap = mock(OptionsMap.class);
+    contactPoints = List.of("127.0.0.1:9042");
+
+    when(optionsMap.get(TypedDriverOption.CONTACT_POINTS)).thenReturn(contactPoints);
+    when(optionsMap.get(TypedDriverOption.SESSION_KEYSPACE)).thenReturn("test_keyspace");
+  }
+
+  @Test
+  public void testConstructor_Valid() {
+    CassandraShard shard = new CassandraShard(optionsMap);
+    assertNotNull("CassandraShard should be created successfully", shard);
+    assertEquals("Keyspace name should match", "test_keyspace", shard.getKeySpaceName());
+    assertEquals("Contact points should match", contactPoints, shard.getContactPoints());
+  }
+
+  @Test
+  public void testConstructor_InvalidContactPoints() {
+    when(optionsMap.get(TypedDriverOption.CONTACT_POINTS)).thenReturn(null);
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> new CassandraShard(optionsMap));
+    assertEquals("CONTACT_POINTS cannot be null or empty.", exception.getMessage());
+  }
+
+  @Test
+  public void testConstructor_InvalidKeySpace() {
+    when(optionsMap.get(TypedDriverOption.SESSION_KEYSPACE)).thenReturn(null);
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> new CassandraShard(optionsMap));
+    assertEquals("SESSION_KEYSPACE cannot be null or empty.", exception.getMessage());
+  }
+
+  @Test
+  public void testExtractAndSetHostAndPort_Valid() {
+    CassandraShard shard = new CassandraShard(optionsMap);
+    assertEquals("Host should be extracted correctly", "127.0.0.1", shard.getHost());
+    assertEquals("Port should be extracted correctly", "9042", shard.getPort());
+  }
+
+  @Test
+  public void testGetters() {
+    CassandraShard shard = new CassandraShard(optionsMap);
+    assertEquals(
+        "Contact points getter should return correct value",
+        contactPoints,
+        shard.getContactPoints());
+    assertEquals(
+        "Keyspace getter should return correct value", "test_keyspace", shard.getKeySpaceName());
+  }
+
+  @Test
+  public void testToString() {
+    CassandraShard shard = new CassandraShard(optionsMap);
+    String expected =
+        String.format(
+            "CassandraShard{logicalShardId='%s', contactPoints=%s, keyspace='%s', host='%s', port='%s'}",
+            shard.getLogicalShardId(), contactPoints, "test_keyspace", "127.0.0.1", "9042");
+    assertEquals("toString should return the expected representation", expected, shard.toString());
+  }
+
+  @Test
+  public void testEqualsAndHashCode_Equal() {
+    CassandraShard shard1 = new CassandraShard(optionsMap);
+    CassandraShard shard2 = new CassandraShard(optionsMap);
+    assertEquals("Equal shards should be considered equal", shard1, shard2);
+    assertEquals(
+        "Equal shards should have the same hash code", shard1.hashCode(), shard2.hashCode());
+  }
+
+  @Test
+  public void testEqualsAndHashCode_ForSameEqual() {
+    CassandraShard shard1 = new CassandraShard(optionsMap);
+    assertEquals("Equal shards should be considered equal", shard1, shard1);
+    assertEquals(
+        "Equal shards should have the same hash code", shard1.hashCode(), shard1.hashCode());
+  }
+
+  @Test
+  public void testEqualsAndHashCode_NotEqual() {
+    CassandraShard shard1 = new CassandraShard(optionsMap);
+    Shard shard2 = new Shard();
+    assertNotEquals("Equal shards should be considered equal", shard1, shard2);
+    assertNotEquals(
+        "Equal shards should have the same hash code", shard1.hashCode(), shard2.hashCode());
+  }
+
+  @Test
+  public void testGetUsername() {
+    CassandraShard shard = new CassandraShard(optionsMap);
+    String expectedUsername = "user123";
+    when(optionsMap.get(TypedDriverOption.AUTH_PROVIDER_USER_NAME)).thenReturn(expectedUsername);
+    String actualUsername = shard.getUsername();
+    assertEquals(
+        "Username should match the one in the options map", expectedUsername, actualUsername);
+  }
+
+  @Test
+  public void testGetOptionsMap() {
+    CassandraShard shard = new CassandraShard(optionsMap);
+    OptionsMap returnedOptionsMap = shard.getOptionsMap();
+    assertSame(
+        "The options map returned should be the same as the one passed to the constructor",
+        optionsMap,
+        returnedOptionsMap);
+  }
+
+  @Test
+  public void testConstructor_InvalidKeySpaceNameLength() {
+    String keyspace = "keyspace1";
+    List<String> contactPoints = List.of("localhost");
+    when(optionsMap.get(TypedDriverOption.SESSION_KEYSPACE)).thenReturn(keyspace);
+    when(optionsMap.get(TypedDriverOption.CONTACT_POINTS)).thenReturn(contactPoints);
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> new CassandraShard(optionsMap));
+    assertEquals("Invalid contact point format: localhost", exception.getMessage());
+  }
+
+  @Test
+  public void testEquals_ShouldReturnTrue_WhenContactPointsAndKeyspaceAreSame() {
+    String keyspace = "keyspace1";
+    List<String> contactPoints = List.of("localhost:9042");
+    OptionsMap optionsMap1 = mock(OptionsMap.class);
+    when(optionsMap1.get(TypedDriverOption.SESSION_KEYSPACE)).thenReturn(keyspace);
+    when(optionsMap1.get(TypedDriverOption.CONTACT_POINTS)).thenReturn(contactPoints);
+
+    CassandraShard shard1 = new CassandraShard(optionsMap1);
+    CassandraShard shard2 = new CassandraShard(optionsMap1);
+
+    assertEquals(
+        "CassandraShard objects with the same contactPoints and keyspace should be equal",
+        shard1,
+        shard2);
+  }
+
+  @Test
+  public void testEquals_ShouldReturnFalse_WhenContactPointsAreDifferent() {
+    String keyspace = "keyspace1";
+    List<String> contactPoints1 = List.of("localhost:9042");
+    List<String> contactPoints2 = List.of("localhost:9043");
+    OptionsMap optionsMap1 = mock(OptionsMap.class);
+    when(optionsMap1.get(TypedDriverOption.SESSION_KEYSPACE)).thenReturn(keyspace);
+    when(optionsMap1.get(TypedDriverOption.CONTACT_POINTS)).thenReturn(contactPoints1);
+
+    OptionsMap optionsMap2 = mock(OptionsMap.class);
+    when(optionsMap2.get(TypedDriverOption.SESSION_KEYSPACE)).thenReturn(keyspace);
+    when(optionsMap2.get(TypedDriverOption.CONTACT_POINTS)).thenReturn(contactPoints2);
+
+    CassandraShard shard1 = new CassandraShard(optionsMap1);
+    CassandraShard shard2 = new CassandraShard(optionsMap2);
+
+    assertNotEquals(
+        "CassandraShard objects with different contactPoints should not be equal", shard1, shard2);
+  }
+
+  @Test
+  public void testEquals_ShouldReturnFalse_WhenKeyspaceIsDifferent() {
+    String keyspace1 = "keyspace1";
+    String keyspace2 = "keyspace2";
+    List<String> contactPoints = List.of("localhost:9042");
+    OptionsMap optionsMap1 = mock(OptionsMap.class);
+    when(optionsMap1.get(TypedDriverOption.SESSION_KEYSPACE)).thenReturn(keyspace1);
+    when(optionsMap1.get(TypedDriverOption.CONTACT_POINTS)).thenReturn(contactPoints);
+
+    OptionsMap optionsMap2 = mock(OptionsMap.class);
+    when(optionsMap2.get(TypedDriverOption.SESSION_KEYSPACE)).thenReturn(keyspace2);
+    when(optionsMap2.get(TypedDriverOption.CONTACT_POINTS)).thenReturn(contactPoints);
+
+    CassandraShard shard1 = new CassandraShard(optionsMap1);
+    CassandraShard shard2 = new CassandraShard(optionsMap2);
+
+    assertNotEquals(
+        "CassandraShard objects with different keyspace should not be equal", shard1, shard2);
+  }
+}

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/spanner/SpannerSchemaTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/spanner/SpannerSchemaTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.spanner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.NameAndCols;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SpannerTable;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SpannerSchemaTest {
+
+  @Test
+  public void testSpannerSchemaPopulation() throws Exception {
+    Ddl ddl =
+        Ddl.builder()
+            .createTable("Users")
+            .column("id")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("first_name")
+            .string()
+            .size(10)
+            .endColumn()
+            .column("last_name")
+            .type(com.google.cloud.teleport.v2.spanner.type.Type.string())
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .createTable("Account")
+            .column("id")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("balanceId")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("balance")
+            .float64()
+            .notNull()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .interleaveInParent("Users")
+            .onDeleteCascade()
+            .endTable()
+            .build();
+
+    Map<String, SpannerTable> spannerTables =
+        SpannerSchema.convertDDLTableToSpannerTable(ddl.allTables());
+    assertNotNull(spannerTables);
+
+    SpannerTable usersTable = spannerTables.get("Users");
+    assertNotNull(usersTable);
+    assertEquals("Users", usersTable.getName());
+
+    SpannerTable accountTable = spannerTables.get("Account");
+    assertNotNull(accountTable);
+    assertEquals("Account", accountTable.getName());
+    assertEquals(3, accountTable.getColDefs().size());
+
+    Map<String, NameAndCols> nameAndColsTable =
+        SpannerSchema.convertDDLTableToSpannerNameAndColsTable(ddl.allTables());
+    assertNotNull(nameAndColsTable);
+
+    NameAndCols usersColumns = nameAndColsTable.get("Users");
+    assertNotNull(usersColumns);
+    assertTrue(usersColumns.getCols().containsKey("id"));
+    assertTrue(usersColumns.getCols().containsKey("first_name"));
+    assertTrue(usersColumns.getCols().containsKey("last_name"));
+
+    NameAndCols accountColumns = nameAndColsTable.get("Account");
+    assertNotNull(accountColumns);
+    assertTrue(accountColumns.getCols().containsKey("id"));
+    assertTrue(accountColumns.getCols().containsKey("balanceId"));
+    assertTrue(accountColumns.getCols().containsKey("balance"));
+  }
+}

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/utils/CassandraConfigFileReaderTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/utils/CassandraConfigFileReaderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import com.google.common.io.Resources;
+import java.io.FileNotFoundException;
+import java.net.URL;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(JUnit4.class)
+public class CassandraConfigFileReaderTest {
+
+  private CassandraConfigFileReader cassandraConfigFileReader;
+  private MockedStatic<JarFileReader> mockFileReader;
+
+  @Before
+  public void setUp() {
+    cassandraConfigFileReader = new CassandraConfigFileReader();
+    mockFileReader = Mockito.mockStatic(JarFileReader.class);
+  }
+
+  @After
+  public void tearDown() {
+    if (mockFileReader != null) {
+      mockFileReader.close();
+    }
+  }
+
+  @Test
+  public void testGetCassandraShardSuccess() {
+    String testGcsPath = "gs://smt-test-bucket/cassandraConfig.conf";
+    URL testUrl = Resources.getResource("test-cassandra-config.conf");
+    mockFileReader
+        .when(() -> JarFileReader.saveFilesLocally(testGcsPath))
+        .thenReturn(new URL[] {testUrl});
+
+    List<Shard> shards = cassandraConfigFileReader.getCassandraShard(testGcsPath);
+
+    assertNotNull("The shards list should not be null.", shards);
+    assertEquals("The shards list should contain one shard.", 1, shards.size());
+
+    Logger logger = LoggerFactory.getLogger(CassandraConfigFileReader.class);
+    assertNotNull("Logger should be initialized.", logger);
+  }
+
+  @Test
+  public void testGetCassandraShardFileNotFound() {
+    String testConfigPath = "gs://non-existent-bucket/non-existent-file.yaml";
+
+    try (MockedStatic<CassandraDriverConfigLoader> mockedConfigLoader =
+        Mockito.mockStatic(CassandraDriverConfigLoader.class)) {
+      mockedConfigLoader
+          .when(() -> CassandraDriverConfigLoader.getOptionsMapFromFile(testConfigPath))
+          .thenThrow(new FileNotFoundException("File not found: " + testConfigPath));
+
+      IllegalArgumentException exception = null;
+      try {
+        cassandraConfigFileReader.getCassandraShard(testConfigPath);
+      } catch (IllegalArgumentException e) {
+        exception = e;
+      }
+
+      assertNotNull("Exception should be thrown for missing configuration file.", exception);
+      assertTrue(
+          "Exception message should indicate the missing configuration file.",
+          exception.getMessage().contains("Configuration file not found:"));
+    }
+  }
+}

--- a/v2/spanner-common/src/test/resources/test-cassandra-config.conf
+++ b/v2/spanner-common/src/test/resources/test-cassandra-config.conf
@@ -67,7 +67,7 @@
   # Required: no
   # Modifiable at runtime: no
   # Overridable in a profile: no
-  // basic.session-keyspace = my_keyspace
+   basic.session-keyspace = my_keyspace
 
   # How often the driver tries to reload the configuration.
   #

--- a/v2/spanner-to-sourcedb/pom.xml
+++ b/v2/spanner-to-sourcedb/pom.xml
@@ -89,6 +89,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>LATEST</version> <!-- Use the latest version available -->
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.datastax.oss</groupId>
             <artifactId>java-driver-core</artifactId>
             <version>4.17.0</version> <!-- Use the latest version -->

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/constants/Constants.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/constants/Constants.java
@@ -76,6 +76,8 @@ public class Constants {
 
   public static final String SOURCE_MYSQL = "mysql";
 
+  public static final String SOURCE_CASSANDRA = "cassandra";
+
   // Message written to the file for filtered records
   public static final String FILTERED_TAG_MESSAGE =
       "Filtered record from custom transformation in reverse replication";

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/connection/CassandraConnectionHelper.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/connection/CassandraConnectionHelper.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.dbutils.connection;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.CassandraShard;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.CassandraDriverConfigLoader;
+import com.google.cloud.teleport.v2.templates.exceptions.ConnectionException;
+import com.google.cloud.teleport.v2.templates.models.ConnectionHelperRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@code CassandraConnectionHelper} class provides methods to manage and maintain connections
+ * to a Cassandra database in a multi-shard environment. It implements the {@link IConnectionHelper}
+ * interface for {@link CqlSession}.
+ *
+ * <p>This class initializes and maintains a connection pool for multiple Cassandra shards and
+ * provides utilities to retrieve connections based on a unique key.
+ *
+ * <p>Typical usage:
+ *
+ * <pre>
+ *   CassandraConnectionHelper helper = new CassandraConnectionHelper();
+ *   helper.init(connectionHelperRequest);
+ *   CqlSession session = helper.getConnection(connectionKey);
+ * </pre>
+ */
+public class CassandraConnectionHelper implements IConnectionHelper<CqlSession> {
+
+  /** Logger for logging information and errors. */
+  private static final Logger LOG = LoggerFactory.getLogger(CassandraConnectionHelper.class);
+
+  /** A thread-safe connection pool storing {@link CqlSession} instances mapped to unique keys. */
+  private static Map<String, CqlSession> connectionPoolMap = new ConcurrentHashMap<>();
+
+  /**
+   * Initializes the connection pool with connections for the provided Cassandra shards.
+   *
+   * @param connectionHelperRequest The request object containing shard details and connection
+   *     settings.
+   * @throws IllegalArgumentException if any shard validation fails or invalid shard types are
+   *     provided.
+   */
+  @Override
+  public synchronized void init(ConnectionHelperRequest connectionHelperRequest) {
+    if (connectionPoolMap != null && !connectionPoolMap.isEmpty()) {
+      LOG.info("Connection pool is already initialized.");
+      return;
+    }
+
+    LOG.info(
+        "Initializing Cassandra connection pool with size: {}",
+        connectionHelperRequest.getMaxConnections());
+
+    List<Shard> shards = connectionHelperRequest.getShards();
+    for (Shard shard : shards) {
+      if (!(shard instanceof CassandraShard)) {
+        LOG.error("Invalid shard type: {}", shard.getClass().getSimpleName());
+        throw new IllegalArgumentException("Invalid shard object");
+      }
+
+      CassandraShard cassandraShard = (CassandraShard) shard;
+      try {
+        CqlSession session = createCqlSession(cassandraShard);
+        String connectionKey = generateConnectionKey(cassandraShard);
+        connectionPoolMap.put(connectionKey, session);
+        LOG.info("Connection initialized for key: {}", connectionKey);
+      } catch (Exception e) {
+        LOG.error("Failed to initialize connection for shard: {}", cassandraShard, e);
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Retrieves a {@link CqlSession} connection from the connection pool.
+   *
+   * @param connectionRequestKey The unique key identifying the connection in the pool.
+   * @return The {@link CqlSession} instance associated with the given key.
+   * @throws ConnectionException If the connection pool is not initialized or no connection is found
+   *     for the key.
+   */
+  @Override
+  public CqlSession getConnection(String connectionRequestKey) throws ConnectionException {
+    if (connectionPoolMap == null || connectionPoolMap.isEmpty()) {
+      LOG.warn("Connection pool not initialized.");
+      throw new ConnectionException("Connection pool is not initialized.");
+    }
+
+    CqlSession session = connectionPoolMap.get(connectionRequestKey);
+    if (session == null) {
+      LOG.error("No connection found for key: {}", connectionRequestKey);
+      throw new ConnectionException(
+          "No connection available for the given key: " + connectionRequestKey);
+    }
+
+    return session;
+  }
+
+  /**
+   * Checks if the connection pool is initialized and contains connections.
+   *
+   * @return {@code true} if the connection pool is initialized and not empty; {@code false}
+   *     otherwise.
+   */
+  @Override
+  public boolean isConnectionPoolInitialized() {
+    return connectionPoolMap != null && !connectionPoolMap.isEmpty();
+  }
+
+  /**
+   * Creates a {@link CqlSession} for the given {@link CassandraShard}.
+   *
+   * @param cassandraShard The shard containing connection details.
+   * @return A {@link CqlSession} instance.
+   */
+  private CqlSession createCqlSession(CassandraShard cassandraShard) {
+    CqlSessionBuilder builder = CqlSession.builder();
+    DriverConfigLoader configLoader =
+        CassandraDriverConfigLoader.fromOptionsMap(cassandraShard.getOptionsMap());
+    builder.withConfigLoader(configLoader);
+    return builder.build();
+  }
+
+  /**
+   * Generates a unique connection key for the given {@link CassandraShard}.
+   *
+   * @param shard The shard containing connection details.
+   * @return A string key uniquely identifying the connection.
+   */
+  private String generateConnectionKey(CassandraShard shard) {
+    return String.format(
+        "%s:%s/%s/%s",
+        shard.getHost(), shard.getPort(), shard.getUserName(), shard.getKeySpaceName());
+  }
+
+  /**
+   * Sets the connection pool for testing purposes.
+   *
+   * @param inputMap A map containing pre-configured connections for testing.
+   */
+  public void setConnectionPoolMap(Map<String, CqlSession> inputMap) {
+    connectionPoolMap = inputMap;
+  }
+}

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/processor/SourceProcessorFactory.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/processor/SourceProcessorFactory.java
@@ -15,16 +15,21 @@
  */
 package com.google.cloud.teleport.v2.templates.dbutils.processor;
 
+import com.google.cloud.teleport.v2.spanner.migrations.shard.CassandraShard;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
+import com.google.cloud.teleport.v2.templates.dbutils.connection.CassandraConnectionHelper;
 import com.google.cloud.teleport.v2.templates.dbutils.connection.IConnectionHelper;
 import com.google.cloud.teleport.v2.templates.dbutils.connection.JdbcConnectionHelper;
+import com.google.cloud.teleport.v2.templates.dbutils.dao.source.CassandraDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.IDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.JdbcDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dml.IDMLGenerator;
 import com.google.cloud.teleport.v2.templates.dbutils.dml.MySQLDMLGenerator;
 import com.google.cloud.teleport.v2.templates.exceptions.UnsupportedSourceException;
 import com.google.cloud.teleport.v2.templates.models.ConnectionHelperRequest;
+import com.google.cloud.teleport.v2.templates.models.DMLGeneratorRequest;
+import com.google.cloud.teleport.v2.templates.models.DMLGeneratorResponse;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,20 +38,53 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public class SourceProcessorFactory {
-  private static Map<String, IDMLGenerator> dmlGeneratorMap =
-      Map.of(Constants.SOURCE_MYSQL, new MySQLDMLGenerator());
+  private static Map<String, IDMLGenerator> dmlGeneratorMap = new HashMap<>();
 
-  private static Map<String, IConnectionHelper> connectionHelperMap =
-      Map.of(Constants.SOURCE_MYSQL, new JdbcConnectionHelper());
+  private static Map<String, IConnectionHelper> connectionHelperMap = new HashMap<>();
 
-  private static Map<String, String> driverMap =
-      Map.of(Constants.SOURCE_MYSQL, "com.mysql.cj.jdbc.Driver");
-
-  private static Map<String, Function<Shard, String>> connectionUrl =
+  private static final Map<String, String> driverMap =
       Map.of(
           Constants.SOURCE_MYSQL,
-          shard ->
-              "jdbc:mysql://" + shard.getHost() + ":" + shard.getPort() + "/" + shard.getDbName());
+          "com.mysql.cj.jdbc.Driver", // MySQL JDBC Driver
+          Constants.SOURCE_CASSANDRA,
+          "com.datastax.oss.driver.api.core.CqlSession" // Cassandra Session Class
+          );
+
+  private static Map<String, Function<Shard, String>> connectionUrl = new HashMap<>();
+
+  static {
+    dmlGeneratorMap.put(Constants.SOURCE_MYSQL, new MySQLDMLGenerator());
+    dmlGeneratorMap.put(
+        Constants.SOURCE_CASSANDRA,
+        new IDMLGenerator() {
+          // TODO It will get removed in DML PR added Now for Test case eg: new
+          // CassandraDMLGenerator()
+          @Override
+          public DMLGeneratorResponse getDMLStatement(DMLGeneratorRequest dmlGeneratorRequest) {
+            return new DMLGeneratorResponse("");
+          }
+        });
+
+    connectionHelperMap.put(Constants.SOURCE_MYSQL, new JdbcConnectionHelper());
+    connectionHelperMap.put(Constants.SOURCE_CASSANDRA, new CassandraConnectionHelper());
+
+    connectionUrl.put(
+        Constants.SOURCE_MYSQL,
+        shard ->
+            "jdbc:mysql://" + shard.getHost() + ":" + shard.getPort() + "/" + shard.getDbName());
+    connectionUrl.put(
+        Constants.SOURCE_CASSANDRA,
+        shard -> {
+          CassandraShard cassandraShard = (CassandraShard) shard;
+          return cassandraShard.getHost()
+              + ":"
+              + cassandraShard.getPort()
+              + "/"
+              + cassandraShard.getUserName()
+              + "/"
+              + cassandraShard.getKeySpaceName();
+        });
+  }
 
   private static Map<String, BiFunction<List<Shard>, Integer, ConnectionHelperRequest>>
       connectionHelperRequestFactory =
@@ -58,7 +96,16 @@ public class SourceProcessorFactory {
                       null,
                       maxConnections,
                       driverMap.get(Constants.SOURCE_MYSQL),
-                      "SET SESSION net_read_timeout=1200" // to avoid timeouts at network layer
+                      "SET SESSION net_read_timeout=1200" // To avoid timeouts at the network layer
+                      ),
+              Constants.SOURCE_CASSANDRA,
+              (shards, maxConnections) ->
+                  new ConnectionHelperRequest(
+                      shards,
+                      null,
+                      maxConnections,
+                      driverMap.get(Constants.SOURCE_CASSANDRA),
+                      null // No specific initialization query for Cassandra
                       ));
 
   // for unit testing purposes
@@ -132,7 +179,10 @@ public class SourceProcessorFactory {
     Map<String, IDao> sourceDaoMap = new HashMap<>();
     for (Shard shard : shards) {
       String connectionUrl = urlGenerator.apply(shard);
-      IDao sqlDao = new JdbcDao(connectionUrl, shard.getUserName(), getConnectionHelper(source));
+      IDao sqlDao =
+          source.equals(Constants.SOURCE_MYSQL)
+              ? new JdbcDao(connectionUrl, shard.getUserName(), getConnectionHelper(source))
+              : new CassandraDao(connectionUrl, shard.getUserName(), getConnectionHelper(source));
       sourceDaoMap.put(shard.getLogicalShardId(), sqlDao);
     }
     return sourceDaoMap;

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
@@ -202,7 +202,6 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
 
         if (!isSourceAhead) {
           IDao sourceDao = sourceProcessor.getSourceDao(shardId);
-
           boolean isEventFiltered =
               InputRecordProcessor.processRecord(
                   spannerRec,

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/CassandraSourceSchemaReader.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/CassandraSourceSchemaReader.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.utils;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.CassandraShard;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.CassandraDriverConfigLoader;
+import com.google.cloud.teleport.v2.templates.exceptions.ConnectionException;
+
+public class CassandraSourceSchemaReader {
+  /**
+   * Reads metadata for the specified Cassandra keyspace.
+   *
+   * <p>This method retrieves metadata from the Cassandra system schema, including table names,
+   * column names, column types, and kinds, for the given keyspace. It uses a prepared statement for
+   * safe and efficient execution.
+   *
+   * @param keyspace The name of the Cassandra keyspace for which metadata is to be retrieved. Must
+   *     not be {@code null} or empty.
+   * @param cassandraShard the shard information
+   * @return A {@link ResultSet} containing the metadata rows with columns:
+   *     <ul>
+   *       <li>{@code table_name} - The name of the table.
+   *       <li>{@code column_name} - The name of the column.
+   *       <li>{@code type} - The data type of the column.
+   *       <li>{@code kind} - The column kind (e.g., partition_key, clustering).
+   *     </ul>
+   *
+   * @throws IllegalArgumentException If the provided keyspace name is {@code null} or empty.
+   * @throws ConnectionException If a connection to the Cassandra database could not be established.
+   * @throws Exception If any other unexpected error occurs during the operation.
+   */
+  public static ResultSet getInformationSchemaAsResultSet(CassandraShard cassandraShard)
+      throws Exception {
+    try (CqlSession session = createCqlSession(cassandraShard)) {
+      String query =
+          "SELECT table_name, column_name, type, kind FROM system_schema.columns WHERE keyspace_name = ?";
+
+      PreparedStatement preparedStatement = session.prepare(query);
+      BoundStatement boundStatement = preparedStatement.bind(cassandraShard.getKeySpaceName());
+      return session.execute(boundStatement);
+    }
+  }
+
+  /**
+   * Creates a {@link CqlSession} for the given {@link CassandraShard}.
+   *
+   * @param cassandraShard The shard containing connection details.
+   * @return A {@link CqlSession} instance.
+   */
+  private static CqlSession createCqlSession(CassandraShard cassandraShard) {
+    CqlSessionBuilder builder = CqlSession.builder();
+    DriverConfigLoader configLoader =
+        CassandraDriverConfigLoader.fromOptionsMap(cassandraShard.getOptionsMap());
+    builder.withConfigLoader(configLoader);
+    return builder.build();
+  }
+}

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/connection/CassandraConnectionHelperTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/connection/CassandraConnectionHelperTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.dbutils.connection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.CassandraShard;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.CassandraDriverConfigLoader;
+import com.google.cloud.teleport.v2.templates.exceptions.ConnectionException;
+import com.google.cloud.teleport.v2.templates.models.ConnectionHelperRequest;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class CassandraConnectionHelperTest {
+
+  private CqlSessionBuilder cqlSessionBuilder;
+  private CqlSession cqlSession;
+  private OptionsMap optionsMap;
+  private CassandraShard cassandraShard;
+  private CassandraConnectionHelper connectionHelper;
+  private DriverConfigLoader driverConfigLoader;
+
+  @Before
+  public void setUp() {
+    connectionHelper = new CassandraConnectionHelper();
+    cassandraShard = mock(CassandraShard.class);
+    optionsMap = mock(OptionsMap.class);
+    driverConfigLoader = mock(DriverConfigLoader.class);
+    cqlSessionBuilder = mock(CqlSessionBuilder.class);
+    cqlSession = mock(CqlSession.class);
+  }
+
+  @Test
+  public void testInit_ShouldInitializeConnectionPool() {
+    when(cassandraShard.getHost()).thenReturn("localhost");
+    when(cassandraShard.getPort()).thenReturn("9042");
+    when(cassandraShard.getUserName()).thenReturn("user");
+    when(cassandraShard.getPassword()).thenReturn("password");
+    when(cassandraShard.getKeySpaceName()).thenReturn("mykeyspace");
+    when(cassandraShard.getOptionsMap()).thenReturn(optionsMap);
+
+    try (MockedStatic<CassandraDriverConfigLoader> mockFileReader =
+        Mockito.mockStatic(CassandraDriverConfigLoader.class)) {
+      mockFileReader
+          .when(() -> CassandraDriverConfigLoader.fromOptionsMap(optionsMap))
+          .thenReturn(driverConfigLoader);
+
+      try (MockedStatic<CqlSession> mockedCqlSession = Mockito.mockStatic(CqlSession.class)) {
+        mockedCqlSession.when(CqlSession::builder).thenReturn(cqlSessionBuilder);
+        when(cqlSessionBuilder.withConfigLoader(driverConfigLoader)).thenReturn(cqlSessionBuilder);
+        when(cqlSessionBuilder.build()).thenReturn(cqlSession);
+
+        ConnectionHelperRequest request = mock(ConnectionHelperRequest.class);
+        when(request.getShards()).thenReturn(Collections.singletonList(cassandraShard));
+        when(request.getMaxConnections()).thenReturn(10);
+        connectionHelper.setConnectionPoolMap(new ConcurrentHashMap<>());
+        connectionHelper.init(request);
+        assertTrue(connectionHelper.isConnectionPoolInitialized());
+      }
+    }
+  }
+
+  @Test
+  public void testGetConnection_ShouldReturnValidSession() throws ConnectionException {
+    String connectionKey = "localhost:9042/user/mykeyspace";
+    connectionHelper.setConnectionPoolMap(new ConcurrentHashMap<>());
+    connectionHelper.setConnectionPoolMap(Map.of(connectionKey, cqlSession));
+    CqlSession session = connectionHelper.getConnection(connectionKey);
+    assertNotNull(session);
+    assertEquals(cqlSession, session);
+  }
+
+  @Test
+  public void testGetConnection_ShouldNotReturnValidSession() throws ConnectionException {
+    String connectionKey = "localhost:9042/user/mykeyspace";
+    String connectionKey1 = "localhost:9042/user/mykeyspace1";
+    connectionHelper.setConnectionPoolMap(new ConcurrentHashMap<>());
+    connectionHelper.setConnectionPoolMap(Map.of(connectionKey, cqlSession));
+    assertThrows(
+        ConnectionException.class,
+        () -> {
+          connectionHelper.getConnection(connectionKey1);
+        });
+  }
+
+  @Test
+  public void testConnection_alreadyInitialized() throws ConnectionException {
+    String connectionKey = "localhost:9042/user/mykeyspace";
+    ConnectionHelperRequest request = mock(ConnectionHelperRequest.class);
+    connectionHelper.setConnectionPoolMap(new ConcurrentHashMap<>());
+    connectionHelper.setConnectionPoolMap(Map.of(connectionKey, cqlSession));
+    connectionHelper.init(request);
+    boolean isInitialized = connectionHelper.isConnectionPoolInitialized();
+    assertTrue(isInitialized);
+  }
+
+  @Test
+  public void testGetConnection_ShouldThrowException_WhenConnectionNotFound() {
+    assertThrows(ConnectionException.class, () -> connectionHelper.getConnection("invalidKey"));
+  }
+
+  @Test
+  public void testGetConnection_ShouldThrowConnectionException_WhenPoolNotInitialized() {
+    connectionHelper.setConnectionPoolMap(null);
+    assertThrows(ConnectionException.class, () -> connectionHelper.getConnection("anyKey"));
+  }
+
+  @Test
+  public void testSetConnectionPoolMap_ShouldOverrideConnectionPoolMap()
+      throws ConnectionException {
+    connectionHelper.setConnectionPoolMap(new ConcurrentHashMap<>());
+    connectionHelper.setConnectionPoolMap(Map.of("localhost:9042/user/mykeyspace", cqlSession));
+    connectionHelper.isConnectionPoolInitialized();
+    CqlSession session = connectionHelper.getConnection("localhost:9042/user/mykeyspace");
+    assertNotNull(session);
+    assertEquals(cqlSession, session);
+  }
+
+  @Test
+  public void testGetConnectionPoolNotFound() {
+    connectionHelper.setConnectionPoolMap(Map.of());
+    ConnectionException exception =
+        assertThrows(
+            ConnectionException.class, () -> connectionHelper.getConnection("nonexistentKey"));
+    assertEquals("Connection pool is not initialized.", exception.getMessage());
+  }
+
+  @Test
+  public void testGetConnectionWhenPoolNotInitialized() {
+    connectionHelper.setConnectionPoolMap(null);
+    ConnectionException exception =
+        assertThrows(
+            ConnectionException.class,
+            () -> connectionHelper.getConnection("localhost:9042/testuser/testKeyspace"));
+    assertEquals("Connection pool is not initialized.", exception.getMessage());
+  }
+
+  @Test
+  public void testGetConnectionWithValidKey() throws ConnectionException {
+    String connectionKey = "localhost:9042/testuser/testKeyspace";
+    connectionHelper.setConnectionPoolMap(Map.of(connectionKey, cqlSession));
+
+    CqlSession session = connectionHelper.getConnection(connectionKey);
+    assertEquals(cqlSession, session);
+  }
+
+  @Test
+  public void testInit_ShouldThrowIllegalArgumentException_WhenInvalidShardTypeIsProvided() {
+    Shard invalidShard = mock(Shard.class);
+    ConnectionHelperRequest request = mock(ConnectionHelperRequest.class);
+    when(request.getShards()).thenReturn(Collections.singletonList(invalidShard));
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> connectionHelper.init(request));
+    assertEquals("Invalid shard object", exception.getMessage());
+  }
+
+  @Test
+  public void testInit_ShouldNotInitializeConnectionPool() {
+    when(cassandraShard.getHost()).thenReturn("localhost");
+    when(cassandraShard.getPort()).thenReturn("9042");
+    when(cassandraShard.getUserName()).thenReturn("user");
+    when(cassandraShard.getPassword()).thenReturn("password");
+    when(cassandraShard.getKeySpaceName()).thenReturn("mykeyspace");
+    when(cassandraShard.getOptionsMap()).thenReturn(optionsMap);
+
+    ConnectionHelperRequest request = mock(ConnectionHelperRequest.class);
+    when(request.getShards()).thenReturn(Collections.singletonList(cassandraShard));
+    when(request.getMaxConnections()).thenReturn(10);
+    connectionHelper.setConnectionPoolMap(new ConcurrentHashMap<>());
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> connectionHelper.init(request));
+    assertEquals("The options map must contain a profile named default", exception.getMessage());
+  }
+}

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dao/source/CassandraDaoTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dao/source/CassandraDaoTest.java
@@ -17,6 +17,10 @@ package com.google.cloud.teleport.v2.templates.dbutils.dao.source;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
@@ -30,11 +34,14 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class CassandraDaoTest {
 
   @Mock private IConnectionHelper mockConnectionHelper;
@@ -53,7 +60,7 @@ public class CassandraDaoTest {
 
   @Test
   public void testNullConnectionForWrite() throws Exception {
-    Mockito.when(mockConnectionHelper.getConnection(ArgumentMatchers.anyString())).thenReturn(null);
+    when(mockConnectionHelper.getConnection(anyString())).thenReturn(null);
     ConnectionException exception =
         assertThrows(
             ConnectionException.class,
@@ -69,20 +76,18 @@ public class CassandraDaoTest {
             PreparedStatementValueObject.create("", preparedDmlStatement),
             PreparedStatementValueObject.create("Test", preparedDmlStatement));
 
-    Mockito.when(mockPreparedStatementGeneratedResponse.getDmlStatement())
-        .thenReturn(preparedDmlStatement);
-    Mockito.when(mockPreparedStatementGeneratedResponse.getValues()).thenReturn(values);
-    Mockito.when(mockConnectionHelper.getConnection(ArgumentMatchers.anyString()))
-        .thenReturn(mockSession);
-    Mockito.when(mockSession.prepare(ArgumentMatchers.eq(preparedDmlStatement)))
+    when(mockPreparedStatementGeneratedResponse.getDmlStatement()).thenReturn(preparedDmlStatement);
+    when(mockPreparedStatementGeneratedResponse.getValues()).thenReturn(values);
+    when(mockConnectionHelper.getConnection(anyString())).thenReturn(mockSession);
+    when(mockSession.prepare(ArgumentMatchers.eq(preparedDmlStatement)))
         .thenReturn(mockPreparedStatement);
-    Mockito.when(mockPreparedStatement.bind(ArgumentMatchers.any())).thenReturn(mockBoundStatement);
+    when(mockPreparedStatement.bind(ArgumentMatchers.any())).thenReturn(mockBoundStatement);
 
     cassandraDao.write(mockPreparedStatementGeneratedResponse);
 
-    Mockito.verify(mockSession).prepare(ArgumentMatchers.eq(preparedDmlStatement));
-    Mockito.verify(mockPreparedStatement).bind(ArgumentMatchers.any());
-    Mockito.verify(mockSession).execute(ArgumentMatchers.eq(mockBoundStatement));
+    verify(mockSession).prepare(ArgumentMatchers.eq(preparedDmlStatement));
+    verify(mockPreparedStatement).bind(ArgumentMatchers.any());
+    verify(mockSession).execute(ArgumentMatchers.eq(mockBoundStatement));
   }
 
   @Test
@@ -93,14 +98,12 @@ public class CassandraDaoTest {
             PreparedStatementValueObject.create("", preparedDmlStatement),
             PreparedStatementValueObject.create("Test", preparedDmlStatement));
 
-    Mockito.when(mockPreparedStatementGeneratedResponse.getDmlStatement())
-        .thenReturn(preparedDmlStatement);
-    Mockito.when(mockPreparedStatementGeneratedResponse.getValues()).thenReturn(values);
-    Mockito.when(mockConnectionHelper.getConnection(ArgumentMatchers.anyString()))
-        .thenReturn(mockSession);
-    Mockito.when(mockSession.prepare(ArgumentMatchers.eq(preparedDmlStatement)))
+    when(mockPreparedStatementGeneratedResponse.getDmlStatement()).thenReturn(preparedDmlStatement);
+    when(mockPreparedStatementGeneratedResponse.getValues()).thenReturn(values);
+    when(mockConnectionHelper.getConnection(anyString())).thenReturn(mockSession);
+    when(mockSession.prepare(ArgumentMatchers.eq(preparedDmlStatement)))
         .thenReturn(mockPreparedStatement);
-    Mockito.when(mockPreparedStatement.bind(ArgumentMatchers.any())).thenReturn(mockBoundStatement);
+    when(mockPreparedStatement.bind(ArgumentMatchers.any())).thenReturn(mockBoundStatement);
     Mockito.doThrow(new RuntimeException("Prepared statement execution failed"))
         .when(mockSession)
         .execute(ArgumentMatchers.eq(mockBoundStatement));
@@ -113,18 +116,17 @@ public class CassandraDaoTest {
             });
 
     assertEquals("Prepared statement execution failed", exception.getMessage());
-    Mockito.verify(mockSession).prepare(ArgumentMatchers.eq(preparedDmlStatement));
-    Mockito.verify(mockPreparedStatement).bind(ArgumentMatchers.any());
-    Mockito.verify(mockSession).execute(ArgumentMatchers.eq(mockBoundStatement));
+    verify(mockSession).prepare(ArgumentMatchers.eq(preparedDmlStatement));
+    verify(mockPreparedStatement).bind(ArgumentMatchers.any());
+    verify(mockSession).execute(ArgumentMatchers.eq(mockBoundStatement));
   }
 
   @Test
   public void testWriteWithExceptionHandling() throws Exception {
     String dmlStatement = "INSERT INTO test (id, name) VALUES (?, ?)";
-    Mockito.when(mockPreparedStatementGeneratedResponse.getDmlStatement()).thenReturn(dmlStatement);
-    Mockito.when(mockConnectionHelper.getConnection(ArgumentMatchers.anyString()))
-        .thenReturn(mockSession);
-    Mockito.when(mockSession.prepare(dmlStatement))
+    when(mockPreparedStatementGeneratedResponse.getDmlStatement()).thenReturn(dmlStatement);
+    when(mockConnectionHelper.getConnection(anyString())).thenReturn(mockSession);
+    when(mockSession.prepare(dmlStatement))
         .thenThrow(new RuntimeException("Failed to prepare statement"));
 
     RuntimeException exception =
@@ -135,13 +137,13 @@ public class CassandraDaoTest {
             });
 
     assertEquals("Failed to prepare statement", exception.getMessage());
-    Mockito.verify(mockSession).prepare(dmlStatement);
-    Mockito.verify(mockSession, Mockito.never()).execute(ArgumentMatchers.<Statement<?>>any());
+    verify(mockSession).prepare(dmlStatement);
+    verify(mockSession, never()).execute(ArgumentMatchers.<Statement<?>>any());
   }
 
   @Test
   public void testConnectionExceptionDuringWrite() throws Exception {
-    Mockito.when(mockConnectionHelper.getConnection(ArgumentMatchers.anyString()))
+    when(mockConnectionHelper.getConnection(anyString()))
         .thenThrow(new ConnectionException("Connection failed"));
     ConnectionException exception =
         assertThrows(

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/processor/SourceProcessorFactoryTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/processor/SourceProcessorFactoryTest.java
@@ -18,9 +18,12 @@ package com.google.cloud.teleport.v2.templates.dbutils.processor;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 
+import com.google.cloud.teleport.v2.spanner.migrations.shard.CassandraShard;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
+import com.google.cloud.teleport.v2.templates.dbutils.connection.CassandraConnectionHelper;
 import com.google.cloud.teleport.v2.templates.dbutils.connection.JdbcConnectionHelper;
+import com.google.cloud.teleport.v2.templates.dbutils.dao.source.CassandraDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.JdbcDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dml.MySQLDMLGenerator;
 import com.google.cloud.teleport.v2.templates.exceptions.UnsupportedSourceException;
@@ -81,5 +84,29 @@ public class SourceProcessorFactoryTest {
     int maxConnections = 10;
 
     SourceProcessorFactory.createSourceProcessor("invalid_source", shards, maxConnections);
+  }
+
+  @Test
+  public void testCreateSourceProcessor_cassandra_validSource() throws Exception {
+    CassandraShard mockCassandraShard = Mockito.mock(CassandraShard.class);
+    Mockito.when(mockCassandraShard.getContactPoints()).thenReturn(List.of("localhost:9042"));
+    Mockito.when(mockCassandraShard.getKeySpaceName()).thenReturn("mydatabase");
+    Mockito.when(mockCassandraShard.getLogicalShardId()).thenReturn("shard1");
+
+    List<Shard> shards = List.of(mockCassandraShard);
+    int maxConnections = 10;
+    CassandraConnectionHelper mockConnectionHelper = Mockito.mock(CassandraConnectionHelper.class);
+    doNothing().when(mockConnectionHelper).init(any());
+    SourceProcessorFactory.setConnectionHelperMap(
+        Map.of(Constants.SOURCE_CASSANDRA, mockConnectionHelper));
+    SourceProcessor processor =
+        SourceProcessorFactory.createSourceProcessor(
+            Constants.SOURCE_CASSANDRA, shards, maxConnections);
+
+    Assert.assertNotNull(processor);
+    // ToDo this Particular line will get enable in DML PR
+    //    Assert.assertTrue(processor.getDmlGenerator() instanceof CassandraDMLGenerator);
+    Assert.assertEquals(1, processor.getSourceDaoMap().size());
+    Assert.assertTrue(processor.getSourceDaoMap().get("shard1") instanceof CassandraDao);
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/CassandraSourceSchemaReaderTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/CassandraSourceSchemaReaderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.utils;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.CassandraShard;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class CassandraSourceSchemaReaderTest {
+
+  private CassandraSourceSchemaReader schemaReader;
+  private CqlSession mockSession;
+  private CassandraShard mockCassandraShard;
+  private PreparedStatement mockPreparedStatement;
+  private BoundStatement mockBoundStatement;
+  private ResultSet mockResultSet;
+  private CqlSessionBuilder mockSessionBuilder;
+  private DriverConfigLoader mockConfigLoader;
+  private OptionsMap optionsMap;
+
+  @Before
+  public void setUp() {
+    mockSession = mock(CqlSession.class);
+    mockCassandraShard = mock(CassandraShard.class);
+    mockPreparedStatement = mock(PreparedStatement.class);
+    mockBoundStatement = mock(BoundStatement.class);
+    mockResultSet = mock(ResultSet.class);
+    mockSessionBuilder = mock(CqlSessionBuilder.class);
+    mockConfigLoader = mock(DriverConfigLoader.class);
+    optionsMap = mock(OptionsMap.class);
+  }
+
+  @Test
+  public void testGetInformationSchemaAsResultSet_Success() throws Exception {
+    String keyspace = "test_keyspace";
+    String query =
+        "SELECT table_name, column_name, type, kind FROM system_schema.columns WHERE keyspace_name = ?";
+    when(mockCassandraShard.getKeySpaceName()).thenReturn(keyspace);
+    when(mockCassandraShard.getOptionsMap()).thenReturn(optionsMap);
+    when(mockSession.prepare(query)).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.bind(keyspace)).thenReturn(mockBoundStatement);
+    when(mockSession.execute(mockBoundStatement)).thenReturn(mockResultSet);
+
+    try (MockedStatic<CqlSession> mockedSession = Mockito.mockStatic(CqlSession.class)) {
+      mockedSession.when(CqlSession::builder).thenReturn(mockSessionBuilder);
+      when(mockSessionBuilder.withConfigLoader(any(DriverConfigLoader.class)))
+          .thenReturn(mockSessionBuilder);
+      when(mockSessionBuilder.build()).thenReturn(mockSession);
+
+      ResultSet resultSet =
+          CassandraSourceSchemaReader.getInformationSchemaAsResultSet(mockCassandraShard);
+
+      assertNotNull("Result set should not be null", resultSet);
+      verify(mockPreparedStatement, times(1)).bind(keyspace);
+      verify(mockSession, times(1)).execute(mockBoundStatement);
+    }
+  }
+}


### PR DESCRIPTION
* Added Connection Helper

* Added Formatter

* Added File Reader

* Refectored

* Added Changes for Schema and Spanner Schema

* Added Schema Changes to read Spanner Table in Schema object

* Added Schema Changes

* Added Changes for Schma

* Added Source Writn Fn Changes

* Added Source Factory Changes

* Added Fixed for the Source factory and Casssandra Connection helper

* Added Cassandra Schema Reader

* Added Pipeline Process

* Removed Unwanted Validation

* Added Access validator

* removed unwanted Return

* Added Thread safe optimization in cassandra Connection helper

* Applied  spotless:apply

* spotless:apply

* Added Constructor for Test case

* Added DUMMY Generator For UT

* Fixed UT for Metadata config (#30)



Cassandra metadata PR To accomodate Driver Loader Class (#33)

* Removed *

* Create README.md for UDF samples (#2083)

This commit adds a README.md file to the  directory. The README file provides descriptions for each of the sample Javascript UDF files in the directory, including their purpose and usage examples.



* CassandraDriverConfigLoader from GCS (#2077)

* Added Config File Path

* Added Fix for Loading Driver Options

* Added Dependecy Fixes

* Fix UT

---------




* PR Review Comments (#35)

* Convert it to builder Pattern

* Convert Waring to Error

* remove the unwanted comments

* Removed Unwanted options

* Address the PR

* Address the PR Comments

* Added Missing Getter for Configuration

* Address to removed configuration changes

* removed unwanted getters

* Removal of getter from cassandra dao and test case fixes

* Handle Optionmap in cassandra DAO for serialization

* removed dependecy of getKeyOrder

* Removed And Update Exception

* Fix Checkstyle Voilation

* Missing UT Added (#37)

* Added Dummy Test case

* Removed * from import

* removed unwanted

* Added Fixes

* Added test case and fixes

* Added Some more PR comments

* Added Test case for Cassandra Reader

* Added New testcase

* Added Dependecny

* Update test case  and remove Dependency of Jupiter (#39)

* Update test case  and remove Dependecy of jupiter

* Added UT fixes

* Added Missing Getter for Configuration

* [Sourcedb-to-spanner] Bulk migration Mysql to spanner 1tb Load test (#2063)

* [Sourcedb-to-spanner] Bulk migration Mysql to spanner 1tb Load test

* Updating row counts, added static sql resources

* Renaming the test and addressing comments

* PipelineController Changes for Cassandra (#2086)

* Fix Spanner Load tests and add display test report (#2092)

* correcting lt failures

* Adding test report

* Meta code coverage (#41)

Meta code coverage

* Pr bug fixes (#42)

* Schema Reader Optimization (#43)

* Added Pr Fix related to Changes Year in Javadoc

* Address the revert of 2025 and removal of extra constructor

* Added Extra Testcase to reach target patch

---------