### PR TITLE
fix: eager source row fetching logic (#2071)

### DIFF
--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/utils/ModelUtils.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/utils/ModelUtils.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -38,8 +37,6 @@ import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.commons.lang3.StringUtils;
-import org.neo4j.importer.v1.ImportSpecification;
-import org.neo4j.importer.v1.sources.Source;
 import org.neo4j.importer.v1.targets.Aggregation;
 import org.neo4j.importer.v1.targets.EntityTarget;
 import org.neo4j.importer.v1.targets.NodeTarget;
@@ -57,12 +54,6 @@ import org.slf4j.LoggerFactory;
 public class ModelUtils {
   private static final Pattern variablePattern = Pattern.compile("(\\$([a-zA-Z0-9_]+))");
   private static final Logger LOG = LoggerFactory.getLogger(ModelUtils.class);
-
-  public static boolean targetsHaveTransforms(ImportSpecification jobSpec, Source source) {
-    return jobSpec.getTargets().getAll().stream()
-        .filter(target -> target.isActive() && Objects.equals(target.getSource(), source.getName()))
-        .anyMatch(ModelUtils::targetHasTransforms);
-  }
 
   public static boolean targetHasTransforms(Target target) {
     if (target.getTargetType() == TargetType.QUERY) {

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/templates/SyntheticFieldsIT.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/templates/SyntheticFieldsIT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.neo4j.templates;
+
+import static com.google.cloud.teleport.v2.neo4j.templates.Connections.jsonBasicPayload;
+import static com.google.cloud.teleport.v2.neo4j.templates.Resources.contentOf;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
+import org.apache.beam.it.common.PipelineOperator.Result;
+import org.apache.beam.it.common.TestProperties;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.TemplateTestBase;
+import org.apache.beam.it.neo4j.Neo4jResourceManager;
+import org.apache.beam.it.neo4j.conditions.Neo4jQueryCheck;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@Category(TemplateIntegrationTest.class)
+@TemplateIntegrationTest(GoogleCloudToNeo4j.class)
+@RunWith(JUnit4.class)
+public class SyntheticFieldsIT extends TemplateTestBase {
+
+  private Neo4jResourceManager neo4jClient;
+
+  @Before
+  public void setup() {
+    neo4jClient =
+        Neo4jResourceManager.builder(testName)
+            .setAdminPassword("letmein!")
+            .setHost(TestProperties.hostIp())
+            .build();
+  }
+
+  @After
+  public void tearDown() {
+    ResourceManagerUtils.cleanResources(neo4jClient);
+  }
+
+  @Test
+  // TODO: generate bigquery data set once import-spec supports value interpolation
+  public void importsStackoverflowUsers() throws IOException {
+    String spec = contentOf("/testing-specs/synthetic-fields/spec.yml");
+    gcsClient.createArtifact("spec.yml", spec);
+    gcsClient.createArtifact("neo4j-connection.json", jsonBasicPayload(neo4jClient));
+
+    LaunchConfig.Builder options =
+        LaunchConfig.builder(testName, specPath)
+            .addParameter("jobSpecUri", getGcsPath("spec.yml"))
+            .addParameter("neo4jConnectionUri", getGcsPath("neo4j-connection.json"));
+    LaunchInfo info = launchTemplate(options);
+
+    Result result =
+        pipelineOperator()
+            .waitForCondition(
+                createConfig(info),
+                Neo4jQueryCheck.builder(neo4jClient)
+                    .setQuery("MATCH (u:User) RETURN count(u) AS count")
+                    .setExpectedResult(List.of(Map.of("count", 10L)))
+                    .build(),
+                Neo4jQueryCheck.builder(neo4jClient)
+                    .setQuery(
+                        "MATCH (l:Letter) WITH DISTINCT toUpper(l.char) AS char ORDER BY char ASC RETURN collect(char) AS chars")
+                    .setExpectedResult(
+                        List.of(Map.of("chars", List.of("A", "C", "G", "I", "J", "T", "W"))))
+                    .build());
+    assertThatResult(result).meetsConditions();
+  }
+}

--- a/v2/googlecloud-to-neo4j/src/test/resources/testing-specs/synthetic-fields/spec.yml
+++ b/v2/googlecloud-to-neo4j/src/test/resources/testing-specs/synthetic-fields/spec.yml
@@ -1,0 +1,45 @@
+version: '1'
+sources:
+  - type: bigquery
+    name: so_users
+    # once value interpolation is supported by import-spec, this public data set query
+    # will be replaced by a query against a generated test bigquery data set
+    query: |-
+      SELECT id, display_name
+      FROM 
+        `bigquery-public-data.stackoverflow.users`
+      ORDER BY id ASC
+      LIMIT 10
+targets:
+  nodes:
+    - name: users
+      source: so_users
+      write_mode: merge
+      labels: [User]
+      source_transformations:
+        aggregations:
+          - expression: max(id)
+            field_name: max_id
+      properties:
+        - source_field: id
+          target_property: id
+        - source_field: display_name
+          target_property: name
+        - source_field: max_id
+          target_property: max_id
+      schema:
+        key_constraints:
+          - name: key_user_id
+            label: User
+            properties: [id]
+  queries:
+    # here we just need a custom query from the same source as another node/rel target that defines transformations
+    - name: user_name_starts_with
+      depends_on:
+        - users
+      source: so_users
+      query: |-
+        UNWIND $rows AS row 
+        MATCH (user:User {id: row.id})
+        MERGE (letter:Letter {char: left(user.name, 1)})
+        CREATE (user)-[:NAME_STARTS_WITH]->(letter)


### PR DESCRIPTION
This is an old bug which could only surface with the more recent addition of custom Cypher queries.

The template tries to pre-fetch source data.

It does it for text sources, since they do not support SQL pushdown, so their data is required for post-processing anyway.

Before this commit, the template also pre-fetched data when none of the source's targets defined source transformations.

This is overly restrictive and actually wrong.

Custom query targets cannot define source transformations.

If they share a source with a node/rel targets that define custom source transformations, then the template would crash with a NPE.

This is now fixed. Source data is pre-fetched as long as there is at least one of its target that does not define any transformation.

The commit also adds another small optimization: if the source does not match any active targets, the source processing is skipped completely. Before that, the data could be pre-fetched, incurring unnecessary data movement.